### PR TITLE
test: add async SQLModel export tests with FK support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docs
 /enhancement_plan.md
 poetry.lock
 .claude
+/test_debug.db

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ lazy_db = get_lazy_class(engine)
 
 # In any async context:
 orders = await lazy_db.get("orders")
+
+# Async tables also support schema generation
+Order = orders.as_sqlmodel()
 ```
 
 ### Pydantic v2 schema generation

--- a/lazy_alchemy/lazy_alchemy.py
+++ b/lazy_alchemy/lazy_alchemy.py
@@ -401,7 +401,7 @@ class AsyncLazyDBAccessor:
 
             async with self._engine.connect() as conn:
                 table = await conn.run_sync(
-                    lambda sync_conn: Table(
+                    lambda sync_conn: CustomTable(
                         table_name,
                         self._metadata,
                         schema=self._schema,

--- a/specifications/architecture.md
+++ b/specifications/architecture.md
@@ -3,16 +3,20 @@
 **Purpose**: Lazy-Alchemy is a SQLAlchemy wrapper that loads database model metadata lazily instead of at startup, dramatically improving startup time for projects with many models.
 
 **Core Components**:
+
 - `lazy_alchemy/lazy_alchemy.py` - Main module containing:
-  - `CustomTable` - Subclass of SQLAlchemy `Table` with attribute access delegation to `Table.c`
-  - `LazyDBProp` - Descriptor that lazily loads table metadata on first access via `autoload=True`
-  - `get_lazy_class(engine)` - Factory function that creates a dynamic lazy-loaded class bound to an engine
+  - `CustomTable` - Subclass of SQLAlchemy `Table` with attribute access delegation to `Table.c`, plus `as_pydantic()`, `as_pydantic_partial()`, and `as_sqlmodel()` methods
+  - `LazyDBProp` - Descriptor that lazily loads table metadata on first access via `autoload_with=conn`
+  - `get_lazy_class(engine)` - Factory function that creates either a sync `LazyDB` or async `AsyncLazyDBAccessor` depending on engine type
+  - `AsyncLazyDBAccessor` - Awaitable table accessor for async engines with `asyncio.Lock` double-checked locking
 - `lazy_alchemy/__init__.py` - Exports `get_lazy_class`, `CustomTable`, and `version`
 
 **How Lazy Loading Works**:
-1. `get_lazy_class()` creates a dynamically-named class (e.g., `LazyClass_dbname`) with `__getattr__` overridden
+
+1. `get_lazy_class()` creates a dynamically-named class (e.g., `LazyClass_dbname`) with `__getattr__` overridden, or an `AsyncLazyDBAccessor` for async engines
 2. On first attribute access (e.g., `lazy_class.user`), `__getattr__` creates a `LazyDBProp` descriptor and assigns it as a class attribute
-3. Subsequent accesses go directly to the descriptor's `__get__`, which loads the table via `autoload=True` on first call
+3. Subsequent accesses go directly to the descriptor's `__get__`, which loads the table via `autoload_with=conn` on first call
 4. This defers metadata loading until each table is actually referenced
+5. For async engines, `lazy_db.get("table_name")` returns an awaitable that uses `asyncio.Lock` for double-checked locking before reflection
 
 **Version**: `lazy_alchemy/VERSION` (single line file, read via `pathlib.Path.read_text()`)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy import create_engine, Column, String, Integer, Index
+from sqlalchemy import create_engine, Column, String, Integer, Index, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.asyncio import create_async_engine
 
@@ -11,6 +11,14 @@ class User(Base):
     username = Column("username", String(20), primary_key=True)
     age = Column("age", Integer)
     __table_args__ = (Index("idx_user_username", "username"),)
+
+
+class Address(Base):
+    __tablename__ = "address"
+    id = Column("id", Integer, primary_key=True)
+    user_username = Column("user_username", String(20), ForeignKey("user.username"))
+    city = Column("city", String(50))
+    __table_args__ = (Index("idx_address_user", "user_username"),)
 
 
 @pytest.fixture

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -51,3 +51,36 @@ async def test_async_double_checked_locking(async_engine):
     table2 = await lazy_db.get("user")
 
     assert table1.name == table2.name == "user"
+
+
+@pytest.mark.asyncio
+async def test_async_as_sqlmodel(async_engine):
+    """Test exporting async table to SQLModel."""
+    lazy_db = get_lazy_class(async_engine)
+    table = await lazy_db.get("user")
+    User = table.as_sqlmodel()
+    assert User.__tablename__ == "user"
+    assert "username" in User.model_fields
+    assert "age" in User.model_fields
+
+
+@pytest.mark.asyncio
+async def test_async_as_sqlmodel_with_fk(async_engine):
+    """Test that async table with FK exports SQLModel with foreign key attribute."""
+    lazy_db = get_lazy_class(async_engine)
+    table = await lazy_db.get("address")
+    Address = table.as_sqlmodel()
+    assert Address.__tablename__ == "address"
+    assert "id" in Address.model_fields
+    assert "user_username" in Address.model_fields
+    assert "city" in Address.model_fields
+    # Verify the primary key field metadata
+    id_field = Address.model_fields["id"]
+    assert id_field.metadata[0].primary_key is True
+    # Verify the foreign key field metadata
+    user_username_field = Address.model_fields["user_username"]
+    assert user_username_field.metadata[0].foreign_key == "user.username"
+    # Verify city is a regular field (no pk/fk set)
+    city_field = Address.model_fields["city"]
+    assert city_field.metadata[0].primary_key is not True
+    assert city_field.metadata[0].foreign_key is not True


### PR DESCRIPTION
## Summary

- Add `Address` table with FK to `user.username` in conftest.py for async FK testing
- Fix async table reflection (`AsyncLazyDBAccessor.get()`) to use `CustomTable` instead of plain `Table`, enabling `as_sqlmodel()` on async tables
- Add `test_async_as_sqlmodel` test case for basic async SQLModel export
- Add `test_async_as_sqlmodel_with_fk` test case verifying FK attributes are correctly exported in SQLModel metadata
- Update `architecture.md` with async components and schema generation methods
- Update `README.md` with async SQLModel example

## Test plan

- [x] `pytest tests/test_async.py -v` — all 7 tests pass
- [x] `pytest tests/test_sqlmodel.py -v` — all 3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)